### PR TITLE
Correctly specify cosign version

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -34,7 +34,7 @@ runs:
     - name: Setup cosign
       uses: sigstore/cosign-installer@main
       with:
-        version: v1.5.2
+        cosign-release: v1.5.2
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v1.2.0


### PR DESCRIPTION
`cosign-installer` doesn't take a `version` param, which causes a warning in https://github.com/distroless/static/runs/5608554205?check_suite_focus=true#step:4:7

I believe as-is it ends up using the default cosign version param, which is [currently `1.6.0`](https://github.com/sigstore/cosign-installer/blob/b4f55743d10d066fee1de1cf0fa26069700c0195/action.yml