### PR TITLE
Include annotations in signature

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -58,7 +58,11 @@ runs:
         password: ${{ inputs.token }}
 
     - shell: bash
+      env:
+        COSIGN_EXPERIMENTAL: "true"
       run: |
-        # TODO: Add attributes based on things like the commit.
-        COSIGN_EXPERIMENTAL=true cosign sign ${{ steps.apko.outputs.digest }}
+        cosign sign ${{ steps.apko.outputs.digest }} \
+            -a sha=${{ github.sha }} \
+            -a run_id=${{ github.run_id }} \
+            -a run_attempt=${{ github.run_attempt }}
 


### PR DESCRIPTION
This annotates the commit SHA, and the GitHub Actions workflow run number and attempt (in case of re-runs)