### PR TITLE
Add support for new --use-docker-mediatypes flag

### DIFF
--- a/apko-build/README.md
+++ b/apko-build/README.md
@@ -13,6 +13,9 @@ given a config file and base tag to use and output that to a tar file, this does
     config: foo.yaml
     # tag is the base tag to use, required.
     tag: ghcr.io/distroless/foo
+    # use-docker-mediatypes is whether or not to use Docker mediatypes.
+    # Optional.
+    use-docker-mediatypes: false
 ```
 
 ## Scenarios

--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -26,7 +26,7 @@ inputs:
 
 runs:
   using: docker
-  image: "docker://ghcr.io/chainguard-dev/apko:canary"
+  image: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
   entrypoint: /bin/sh
   args:
     - '-c'

--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -18,14 +18,22 @@ inputs:
       The tag to use for building the image.
     required: true
 
+  use-docker-mediatypes:
+    description: |
+      Use Docker mediatypes for building the image.
+    type: boolean
+    required: false
+
 runs:
   using: docker
-  image: "docker://ghcr.io/chainguard-dev/apko:v0.3.3"
+  image: "docker://ghcr.io/chainguard-dev/apko:canary"
   entrypoint: /bin/sh
   args:
     - '-c'
     - |
       set -o errexit
 
-      /ko-app/apko build ${{ inputs.config }} ${{ inputs.tag }} output.tar
+      /ko-app/apko build \
+        ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
+        ${{ inputs.config }} ${{ inputs.tag }} output.tar
       echo EXIT CODE: $?

--- a/apko-snapshot/README.md
+++ b/apko-snapshot/README.md
@@ -15,6 +15,9 @@ The resulting image is signed with `cosign` keyless signing.
     config: foo.yaml
     # Base-tag is the base tag to use, required.
     base-tag: ghcr.io/distroless/foo
+    # use-docker-mediatypes is whether or not to use Docker mediatypes.
+    # Optional.
+    use-docker-mediatypes: false
 ```
 
 ## Scenarios

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -80,7 +80,7 @@ runs:
 
     # Only publish the versioned tag to start.  After we have signed and
     # attested things, then we use crane to update :latest below.
-    - uses: jdolitsky/actions/apko-build@use-oci-mediatypes-testing
+    - uses: chainguard-dev/actions/apko-build@main
       id: apko
       with:
         config: ${{ inputs.config }}

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -46,6 +46,12 @@ inputs:
       The exit code for Trivy to use when vulnerabilities are encountered.
     default: "1"
 
+  use-docker-mediatypes:
+    description: |
+      Use Docker mediatypes for building the image.
+    type: boolean
+    required: false
+
 outputs:
   digest:
     value: ${{ steps.apko.outputs.digest }}
@@ -74,12 +80,13 @@ runs:
 
     # Only publish the versioned tag to start.  After we have signed and
     # attested things, then we use crane to update :latest below.
-    - uses: chainguard-dev/actions/apko-build@main
+    - uses: jdolitsky/actions/apko-build@use-oci-mediatypes-testing
       id: apko
       with:
         config: ${{ inputs.config }}
         tag: ${{ inputs.base-tag }}:${{ inputs.target-tag }}-${{ steps.snapshot-date.outputs.date }}
         source-date-epoch: ${{ steps.snapshot-date.outputs.epoch }}
+        use-docker-mediatypes: ${{ inputs.use-docker-mediatypes }}
 
     - uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b # v1.13.0
       with:


### PR DESCRIPTION
See https://github.com/chainguard-dev/apko/pull/210

Probably need to hold merge until there is a new apko release? Then again it is not used by default