### PR TITLE
Use canary image and move `chainguard-dev/actions/apko-build`

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -24,12 +24,6 @@ inputs:
     type: boolean
     required: false
 
-  retry-count:
-    description: |
-      If the command fail how many times we will retry (default: 2).
-    required: false
-    default: 2
-
 runs:
   using: docker
   image: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
@@ -39,18 +33,7 @@ runs:
     - |
       set -o errexit
 
-      n=0
-      status=0
-      until [ "$n" -ge ${{ inputs.retry-count }} ]
-      do
-        /ko-app/apko build \
-          ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
-          ${{ inputs.config }} ${{ inputs.tag }} output.tar && status=0 && break
-
-        status=1
-        echo "apko build failed, will retry after 15 seconds..."
-        n=$((n+1))
-        sleep 15
-      done
-
-      echo EXIT CODE: $status
+      /ko-app/apko build \
+        ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
+        ${{ inputs.config }} ${{ inputs.tag }} output.tar
+      echo EXIT CODE: $?

--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -24,6 +24,12 @@ inputs:
     type: boolean
     required: false
 
+  retry-count:
+    description: |
+      If the command fail how many times we will retry (default: 2).
+    required: false
+    default: 2
+
 runs:
   using: docker
   image: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
@@ -33,7 +39,18 @@ runs:
     - |
       set -o errexit
 
-      /ko-app/apko build \
-        ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
-        ${{ inputs.config }} ${{ inputs.tag }} output.tar
-      echo EXIT CODE: $?
+      n=0
+      status=0
+      until [ "$n" -ge ${{ inputs.retry-count }} ]
+      do
+        /ko-app/apko build \
+          ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
+          ${{ inputs.config }} ${{ inputs.tag }} output.tar && status=0 && break
+
+        status=1
+        echo "apko build failed, will retry after 15 seconds..."
+        n=$((n+1))
+        sleep 15
+      done
+
+      echo EXIT CODE: $status

--- a/apko-publish/README.md
+++ b/apko-publish/README.md
@@ -1,0 +1,35 @@
+# APKO Publish
+
+This action builds and publish an image with APKO given a config file and tag to use.
+
+## Usage
+
+```yaml
+- uses: distroless/actions/apko-publish@main
+  with:
+    # Config is the configuration file to use for the image build.
+    # Optional, will use .apko.yaml without a defined one.
+    config: foo.yaml
+    # Tag is the tag that will be published.
+    # Required.
+    tag: ghcr.io/chainguard-dev/apko-example:latest
+    # Image Refs is the path to a file where apko should emit a newline
+    # delimited list of published image digests.
+    # Optional, will use a temporary file when unspecified.
+    image_refs: foo.images
+```
+
+## Scenarios
+
+```yaml
+steps:
+- uses: distroless/actions/apko-publish@main
+  id: apko
+  with:
+    config: nginx.yaml
+    tag: ghcr.io/distroless/apko-example:nginx
+
+- shell: bash
+  run: |
+    COSIGN_EXPERIMENTAL=true cosign sign ${{ steps.apko.outputs.digest }}
+```

--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -54,21 +54,14 @@ inputs:
     type: boolean
     required: false
 
-  retry-count:
-    description: |
-      If the command fail how many times we will retry (default: 2).
-    required: false
-    default: 2
-
 outputs:
   digest:
     description: |
       The digest of the published container image.
 
-
 runs:
   using: docker
-  image: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
+  image: "docker://ghcr.io/chainguard-dev/apko:canary"
   env:
     # Set up go-containerregistry's GitHub keychain.
     GITHUB_ACTOR: ${{ inputs.repository_owner }}
@@ -78,25 +71,11 @@ runs:
     - '-c'
     - |
       set -o errexit
-
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
       [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
-
-      n=0
-      status=0
-      until [ "$n" -ge ${{ inputs.retry-count }} ]
-      do
-        /ko-app/apko publish \
-          ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
-          --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs \
-          && status=0 && break
-
-        status=1
-        echo "apko publish failed, will retry after 15 seconds..."
-        n=$((n+1))
-        sleep 15
-      done
-
-      echo EXIT CODE: $status
+      /ko-app/apko publish \
+        ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs
+      echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat "${{ inputs.image_refs }}")

--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -1,0 +1,102 @@
+# Copyright 2022 The Distroless Authors
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Build image with apko'
+description: |
+  This action build an OCI image with apko, given a config file
+  and tag to use.
+
+inputs:
+  config:
+    description: |
+      The config file to use for building the image.
+    default: .apko.yaml
+
+  tag:
+    description: |
+      The tag to use for publishing the image.
+    required: true
+
+  repository_owner:
+    description: |
+      The repository owner's GitHub username.
+    default: ${{ github.repository_owner }}
+
+  token:
+    description: |
+      The repository owner's GitHub token.
+    default: ${{ github.token }}
+
+  image_refs:
+    description: |
+      The value to pass to --image-refs.
+    default: /tmp/apko.images
+
+  keyring-append:
+    description: |
+      The value to pass to --keyring-append.
+    default: ''
+
+  archs:
+    description: |
+      The architectures to build for.
+    default: ''
+
+  source-date-epoch:
+    description: |
+      The UNIX timestamp to use as the source date when building an image.
+      This is set as the SOURCE_DATE_EPOCH environment variable.
+    default: ''
+
+  use-docker-mediatypes:
+    description: |
+      Use Docker mediatypes for building the image.
+    type: boolean
+    required: false
+
+  retry-count:
+    description: |
+      If the command fail how many times we will retry (default: 2).
+    required: false
+    default: 2
+
+outputs:
+  digest:
+    description: |
+      The digest of the published container image.
+
+
+runs:
+  using: docker
+  image: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
+  env:
+    # Set up go-containerregistry's GitHub keychain.
+    GITHUB_ACTOR: ${{ inputs.repository_owner }}
+    GITHUB_TOKEN: ${{ inputs.token }}
+  entrypoint: /bin/sh
+  args:
+    - '-c'
+    - |
+      set -o errexit
+
+      [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
+      [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
+      [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
+
+      n=0
+      status=0
+      until [ "$n" -ge ${{ inputs.retry-count }} ]
+      do
+        /ko-app/apko publish \
+          ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
+          --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs \
+          && status=0 && break
+
+        status=1
+        echo "apko publish failed, will retry after 15 seconds..."
+        n=$((n+1))
+        sleep 15
+      done
+
+      echo EXIT CODE: $status
+      echo ::set-output name=digest::$(cat "${{ inputs.image_refs }}")

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -90,7 +90,7 @@ runs:
 
     # Only publish the versioned tag to start.  After we have signed and
     # attested things, then we use crane to update :latest below.
-    - uses: cpanato/actions/apko-build@retry
+    - uses: distroless/actions/apko-publish@main
       id: apko
       with:
         config: ${{ inputs.config }}

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -90,7 +90,7 @@ runs:
 
     # Only publish the versioned tag to start.  After we have signed and
     # attested things, then we use crane to update :latest below.
-    - uses: chainguard-dev/actions/apko-build@main
+    - uses: cpanato/actions/apko-build@retry
       id: apko
       with:
         config: ${{ inputs.config }}


### PR DESCRIPTION
- use canary image that have a fix for the retry logic
- move action `chainguard-dev/actions/apko-build` to here and call it `distroless/actions/apko-publish`