### PR TITLE
Pin apko image to latest commit

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -24,14 +24,10 @@ inputs:
     type: boolean
     required: false
   
-  apko-image:
-    description: |
-      The apko image to use for building the image
-    default: "docker://ghcr.io/chainguard-dev/apko:v0.4.0"
 
 runs:
   using: docker
-  image:  ${{ inputs.apko-image }}
+  image:  "docker://ghcr.io/chainguard-dev/apko:9eb34d60d6334bb5d3df4885b37abc7edab06eeb"
   entrypoint: /bin/sh
   args:
     - '-c'


### PR DESCRIPTION
Looks like Github actions doesn't support using inputs for the image name.

Error from https://github.com/distroless/template/runs/7148670181?check_suite_focus=true:

```
Error: distroless/actions/main/apko-build/action.yaml (Line: 34, Col: 11):
Error: distroless/actions/main/apko-build/action.yaml (Line: 34, Col: 11): Unrecognized named-value: 'inputs'. Located at position 1 within expression: inputs.apko-image
```

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>