### PR TITLE
Use the distroless action.

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -90,7 +90,7 @@ runs:
 
     # Only publish the versioned tag to start.  After we have signed and
     # attested things, then we use crane to update :latest below.
-    - uses: chainguard-dev/actions/apko-build@main
+    - uses: distroless/actions/apko-build@main
       id: apko
       with:
         config: ${{ inputs.config }}


### PR DESCRIPTION
The snapshot action should point to the distroless build one, not the chainguard one. If it doesn't work we need to fix it...