### PR TITLE
Make build inputs match publish.

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -13,6 +13,22 @@ inputs:
     default: .apko.yaml
     required: false
 
+  keyring-append:
+    description: |
+      The value to pass to --keyring-append.
+    default: ''
+
+  archs:
+    description: |
+      The architectures to build for.
+    default: ''
+
+  source-date-epoch:
+    description: |
+      The UNIX timestamp to use as the source date when building an image.
+      This is set as the SOURCE_DATE_EPOCH environment variable.
+    default: ''
+
   tag:
     description: |
       The tag to use for building the image.
@@ -27,14 +43,16 @@ inputs:
 
 runs:
   using: docker
-  image:  "docker://ghcr.io/chainguard-dev/apko:9eb34d60d6334bb5d3df4885b37abc7edab06eeb"
+  image:  "docker://ghcr.io/chainguard-dev/apko:canary"
   entrypoint: /bin/sh
   args:
     - '-c'
     - |
       set -o errexit
-
+      [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
+      [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
+      [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
       /ko-app/apko build \
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
-        ${{ inputs.config }} ${{ inputs.tag }} output.tar
+        ${{ inputs.config }} ${{ inputs.tag }} output.tar $keys $archs
       echo EXIT CODE: $?


### PR DESCRIPTION
Added keys and archs to build input.

Also changed to use canary version.

Signed-off-by: Adrian Mouat <adrian@chainguard.dev>