### PR TITLE
[apko-snapshot] Add support for pushing additional tags

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -62,6 +62,11 @@ inputs:
       The architectures to build for.
     default: ''
 
+  additional-tags:
+    description: |
+      Additional tags for the final image.
+    default: ''
+
   debug:
     description: |
       Enable debug logging.
@@ -186,3 +191,9 @@ runs:
     - shell: bash
       run: |
         crane cp ${{ steps.apko.outputs.digest }} ${{ inputs.base-tag }}:${{ inputs.target-tag }}
+        
+        for tag in $(echo ${{ inputs.additional-tags }} | sed "s/,/ /g")
+        do
+          crane cp ${{ steps.apko.outputs.digest }} ${{ inputs.base-tag }}:$tag
+        done
+


### PR DESCRIPTION
we can use this for nginx to start tagging the image with the nginx version

Signed-off-by: Priya Wadhwa <priya@chainguard.dev>