### PR TITLE
Now that digest is singular, sign using `${{ inputs.image_refs }}`

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -128,7 +128,7 @@ runs:
       env:
         COSIGN_EXPERIMENTAL: "true"
       run: |
-        cosign sign ${{ steps.apko.outputs.digest }} \
+        cosign sign $(cat ${{ inputs.image_refs }}) \
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
             -a run_attempt=${{ github.run_attempt }}


### PR DESCRIPTION
Signed-off-by: Matt Moore <mattmoor@chainguard.dev>