### PR TITLE
Make the default value of `image_refs` shared with docker action.

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -76,7 +76,7 @@ inputs:
   image_refs:
     description: |
       The value to pass to --image-refs.
-    default: /tmp/apko.images
+    default: apko.images
 
 outputs:
   digest:


### PR DESCRIPTION
The default value for `image_refs` was `/tmp/apko.images`, which wouldn't be visible after the `apko` step because it is executed inside of a container.

This changes it to a workspace-relative path, which is volume mounted in and shared with the rest of the workflow.