### PR TITLE
Update cosign dep to v1.9.0

### DIFF
--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -90,7 +90,7 @@ runs:
     - name: Setup cosign
       uses: sigstore/cosign-installer@main
       with:
-        cosign-release: v1.8.0
+        cosign-release: v1.9.0
 
     - uses: imjasonh/setup-crane@v0.1
 


### PR DESCRIPTION
Cosign v1.8.0 panics when verifying keyless signatures, due to a recent TUF metadata change.