### PR TITLE
Refactor image-refs outputs

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -29,7 +29,7 @@ inputs:
 
   image_refs:
     description: |
-      The value to pass to --image-refs.
+      (DEPRECATED) The value to pass to --image-refs.
     default: /tmp/apko.images
 
   keyring-append:
@@ -75,6 +75,9 @@ outputs:
   digest:
     description: |
       The digest of the published container image.
+  image-refs:
+    description: |
+      All the image and index refs by digest that were built, as a JSON array.
 
 runs:
   using: docker
@@ -103,3 +106,6 @@ runs:
         --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat ${DIGEST_FILE})
+      IMAGE_REFS=$(cat /tmp/apko.images | sed 's/$/\n/g' | grep -v '^$' | jq -R -s -c 'split("\n")[:-1]')
+      echo $IMAGE_REFS
+      echo ::set-output name=image-refs::$IMAGE_REFS

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -75,8 +75,8 @@ inputs:
 
   image_refs:
     description: |
-      The value to pass to --image-refs.
-    default: apko.images
+      (DEPRECATED) The value to pass to --image-refs.
+    default: /tmp/apko.images
   
   automount-src:
     description: |
@@ -93,6 +93,10 @@ outputs:
     value: ${{ steps.apko.outputs.digest }}
     description: |
       The digest of the published container image.
+  image-refs:
+    value: ${{ steps.apko.outputs.image-refs }}
+    description: |
+      All the image and index refs by digest that were built, newline delimited.
 
 runs:
   using: composite
@@ -121,7 +125,7 @@ runs:
       with:
         config: ${{ inputs.config }}
         tag: ${{ inputs.base-tag }}:${{ inputs.target-tag }}-${{ steps.snapshot-date.outputs.date }}
-        image_refs: ${{ inputs.image_refs }}
+        images_refs: ${{ inputs.image_refs }}
         source-date-epoch: ${{ steps.snapshot-date.outputs.epoch }}
         use-docker-mediatypes: ${{ inputs.use-docker-mediatypes }}
         keyring-append: ${{ inputs.keyring-append }}
@@ -140,7 +144,13 @@ runs:
       env:
         COSIGN_EXPERIMENTAL: "true"
       run: |
-        cosign sign $(cat ${{ inputs.image_refs }}) \
+        imgs=echo "${{ steps.apko.outputs.image-refs }}" | jq -r '.[]'
+        if [[ ! -z ${{ inputs.image_refs }} ]]; then
+          imgs=$(cat ${{ inputs.image_refs }})
+        fi
+        echo signing $imgs
+
+        cosign sign $imgs \
             -a sha=${{ github.sha }} \
             -a run_id=${{ github.run_id }} \
             -a run_attempt=${{ github.run_attempt }}


### PR DESCRIPTION
This changes apko-publish to emit the image-refs output, and for
apko-snapshot to pass it through.

This has the benefit that image-refs is no longer an input anywhere, and
it's always only /tmp/apko.images internally in apko-publish.

This also attempts to align all images_refs and igmage-refs into a
consistent image-refs.

After this change we'll need to update all the consumers of these
actions accordingly, e.g., https://github.com/distroless/static/compare/main...imjasonh:static:image-refs

Signed-off-by: Jason Hall <jason@chainguard.dev>