### PR TITLE
changing default output to 0 even if not scanned

### DIFF
--- a/vul-scans/action.yaml
+++ b/vul-scans/action.yaml
@@ -280,17 +280,17 @@ runs:
       id: scan-report
       shell: bash
       run: |
-        GRYPE_COUNT="n/a"
+        GRYPE_COUNT="0"
         if [ "${{ inputs.RUN_GRYPE }}" = "true" ]; then
           GRYPE_COUNT=$(cat ${{ steps.grype-scan.outputs.sarif }} | jq '.runs[0].results | length')
         fi
 
-        TRIVY_COUNT="n/a"
+        TRIVY_COUNT="0"
         if [ "${{ inputs.RUN_TRIVY }}" = "true" ]; then
           TRIVY_COUNT=$(cat trivy-results.sarif | jq '.runs[0].results | length')
         fi
 
-        SNYK_COUNT="n/a"
+        SNYK_COUNT="0"
         if [ "${{ inputs.RUN_SNYK }}" = "true" ]; then
           SNYK_COUNT=$(cat snyk.json | jq .uniqueCount)
         fi


### PR DESCRIPTION
For testing if vul count, in the output it is helpful if the default is 0 not n/a. 

To make this work
```bash
if: ${{ steps.scans.outputs.TRIVY_COUNT != '0' || steps.scans.outputs.GRYPE_COUNT != '0' || steps.scans.outputs.SNYK_COUNT != '0'  }}
```
Signed-off-by: James Strong <strong.james.e@gmail.com>