### PR TITLE
Enable usage of /work directory in apko config

### DIFF
--- a/apko-build/action.yaml
+++ b/apko-build/action.yaml
@@ -47,6 +47,16 @@ inputs:
     required: false
     default: false
 
+  automount-src:
+    description: |
+      If this directory is found, create a copy at automount-dest (inside container)
+    default: ${{ github.workspace }}/.apko-automount
+
+  automount-dest:
+    description: |
+      If automount-src is found, create a copy at this location (inside container)
+    default: /work
+
 runs:
   using: docker
   image:  "docker://ghcr.io/chainguard-dev/apko:canary"
@@ -55,6 +65,10 @@ runs:
     - '-c'
     - |
       set -o errexit
+      if [ -d "${{ inputs.automount-src }}" ]; then
+        echo "Creating copy of ${{ inputs.automount-src }} at ${{ inputs.automount-dest }}"
+        cp -r "${{ inputs.automount-src }}" "${{ inputs.automount-dest }}"
+      fi
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
       [ -n "${{ inputs.archs }}" ] && archs="--build-arch ${{ inputs.archs }}"

--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -61,6 +61,16 @@ inputs:
     required: false
     default: false
 
+  automount-src:
+    description: |
+      If this directory is found, create a copy at automount-dest (inside container)
+    default: ${{ github.workspace }}/.apko-automount
+
+  automount-dest:
+    description: |
+      If automount-src is found, create a copy at this location (inside container)
+    default: /work
+
 outputs:
   digest:
     description: |
@@ -79,6 +89,10 @@ runs:
     - |
       set -o errexit
       set -o pipefail
+      if [ -d "${{ inputs.automount-src }}" ]; then
+        echo "Creating copy of ${{ inputs.automount-src }} at ${{ inputs.automount-dest }}"
+        cp -r "${{ inputs.automount-src }}" "${{ inputs.automount-dest }}"
+      fi
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
       [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -77,6 +77,16 @@ inputs:
     description: |
       The value to pass to --image-refs.
     default: apko.images
+  
+  automount-src:
+    description: |
+      In subsequent steps, if this directory is found, create a copy at automount-dest (inside container)
+    default: ${{ github.workspace }}/.apko-automount
+
+  automount-dest:
+    description: |
+      In subsequent steps, if automount-src is found, create a copy at this location (inside container)
+    default: /work
 
 outputs:
   digest:
@@ -117,6 +127,8 @@ runs:
         keyring-append: ${{ inputs.keyring-append }}
         archs: ${{ inputs.archs }}
         debug: ${{ inputs.debug }}
+        automount-src: ${{ inputs.automount-src }}
+        automount-dest: ${{ inputs.automount-dest }}
 
     - uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b # v1.13.0
       with:


### PR DESCRIPTION
Without this, demo code etc. is pretty much forced to use `@local /github/workspace/packages` in apko config, vs something like `@local /work/packages` which is much easier to support (considering apko/melange images treat `/work` as default work dir)