### PR TITLE
making docker login true by default

### DIFF
--- a/vul-scans/action.yaml
+++ b/vul-scans/action.yaml
@@ -33,7 +33,7 @@ inputs:
   DOCKER_LOGIN:
     description: Login for private regsitries
     required: false
-    default: false
+    default: true
 
   debug:
     description: |


### PR DESCRIPTION
If releasing and pushing an image is done in a separate step from scanning, cosign will fail without docker login, this will force it by default. 

Signed-off-by: James Strong <strong.james.e@gmail.com>