### PR TITLE
Add support for --package-version-tag to apko-snapshot and apko-publish

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -22,6 +22,9 @@ inputs:
       The repository owner's GitHub username.
     default: ${{ github.repository_owner }}
 
+  repository:
+    default: ${{ github.repository }}
+
   token:
     description: |
       The repository owner's GitHub token.
@@ -71,6 +74,12 @@ inputs:
       If automount-src is found, create a copy at this location (inside container)
     default: /work
 
+  package-version-tag:
+    description: |
+      apko can tag the final image with the version of the corresponding apk package passed in here.
+    required: false
+    default: ''
+
 outputs:
   digest:
     description: |
@@ -83,6 +92,7 @@ runs:
     # Set up go-containerregistry's GitHub keychain.
     GITHUB_ACTOR: ${{ inputs.repository_owner }}
     GITHUB_TOKEN: ${{ inputs.token }}
+    REPOSITORY: ${{ inputs.repository }}
   entrypoint: /bin/sh
   args:
     - '-c'
@@ -95,11 +105,18 @@ runs:
       fi
       [ -n "${{ inputs.source-date-epoch }}" ] && export SOURCE_DATE_EPOCH='${{ inputs.source-date-epoch }}'
       [ -n "${{ inputs.keyring-append }}" ] && keys="-k ${{ inputs.keyring-append }}"
-      [ -n "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
+      [ -n  "${{ inputs.archs }}" ] && archs="--arch ${{ inputs.archs }}"
+      
+      packageVersionTag="--package-version-tag=${{ inputs.package-version-tag }}"
+      if [ "${{ inputs.package-version-tag }}" == "" ]; then
+        repo=$(echo $REPOSITORY | cut -d'/' -f2)
+        packageVersionTag="--package-version-tag=$repo"
+      fi
+
       export DIGEST_FILE=$(mktemp)
       /ko-app/apko publish \
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
-        ${{ inputs.debug && '--debug' }} \
-        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs | tee ${DIGEST_FILE}
+        '--debug' \
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs $packageVersionTag | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat ${DIGEST_FILE})

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -67,6 +67,12 @@ inputs:
     required: false
     default: ''
 
+  package-version-tag:
+    description: |
+      apko can tag the final image with the version of the corresponding apk package passed in here.
+    required: false
+    default: ''
+
   debug:
     description: |
       Enable debug logging.
@@ -129,6 +135,7 @@ runs:
         debug: ${{ inputs.debug }}
         automount-src: ${{ inputs.automount-src }}
         automount-dest: ${{ inputs.automount-dest }}
+        package-version-tag: ${{ inputs.package-version-tag }}
 
     - uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b # v1.13.0
       with:


### PR DESCRIPTION
If nothing is passed, I just assume that the name of the repo is the package we want to search for (this should work for`distroless/go` or `distroless/nginx` or `distroless/git`, and maybe more). If it fails no biggie, nothing happens! 