### PR TITLE
Add support for apko --tag-suffix feature.

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -80,6 +80,12 @@ inputs:
     required: false
     default: ''
 
+  tag-suffix:
+    description: |
+      Suffix to use with the package-version-tag feature, if any.
+    required: false
+    default: ''
+
 outputs:
   digest:
     description: |
@@ -113,10 +119,12 @@ runs:
         packageVersionTag="--package-version-tag=$repo"
       fi
 
+      tagSuffix="--tag-suffix=${{ inputs.tag-suffix }}"
+
       export DIGEST_FILE=$(mktemp)
       /ko-app/apko publish \
         ${{ inputs.use-docker-mediatypes && '--use-docker-mediatypes' }} \
         '--debug' \
-        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs $packageVersionTag | tee ${DIGEST_FILE}
+        --image-refs="${{ inputs.image_refs }}" ${{ inputs.config }} ${{ inputs.tag }} $keys $archs $packageVersionTag $tagSuffix | tee ${DIGEST_FILE}
       echo EXIT CODE: $?
       echo ::set-output name=digest::$(cat ${DIGEST_FILE})

--- a/apko-snapshot/action.yaml
+++ b/apko-snapshot/action.yaml
@@ -73,6 +73,12 @@ inputs:
     required: false
     default: ''
 
+  tag-suffix:
+    description: |
+      Suffix to use with the package-version-tag feature, if any.
+    required: false
+    default: ''
+
   debug:
     description: |
       Enable debug logging.
@@ -146,6 +152,7 @@ runs:
         automount-src: ${{ inputs.automount-src }}
         automount-dest: ${{ inputs.automount-dest }}
         package-version-tag: ${{ inputs.package-version-tag }}
+        tag-suffix: ${{ inputs.tag-suffix }}
 
     - uses: docker/login-action@bb984efc561711aaa26e433c32c3521176eae55b # v1.13.0
       with:


### PR DESCRIPTION
This is needed to support the glibc variant images.