### PR TITLE
Add additional docker args & escape generic-user

### DIFF
--- a/apko-publish/action.yaml
+++ b/apko-publish/action.yaml
@@ -134,6 +134,12 @@ inputs:
     required: false
     default: ''
 
+  docker-args:
+    description: |
+      Additional arguments to pass to the docker run command.
+    required: false
+    default: ''
+
 outputs:
   digest:
     value: ${{ steps.docker-run.outputs.digest }}
@@ -159,6 +165,7 @@ runs:
         -e "GITHUB_ACTOR=${{ inputs.repository_owner }}" \
         -e "GITHUB_TOKEN=${{ inputs.token }}" \
         -e "REPOSITORY=${{ inputs.repository }}" \
+        ${{ inputs.docker-args }} \
         "${APKO_IMAGE}" \
         -c "$(cat <<"EOF"
       set -o errexit
@@ -166,7 +173,7 @@ runs:
 
       if [[ "${{ inputs.generic-user }}" != "" && "${{ inputs.generic-pass }}" != "" ]]; then
         echo "${{ inputs.generic-pass }}" | \
-          /usr/bin/apko login -u "${{ inputs.generic-user }}" \
+          /usr/bin/apko login -u '${{ inputs.generic-user }}' \
             --password-stdin "$(echo "${{ inputs.tag }}" | cut -d'/' -f1)"
       fi
 


### PR DESCRIPTION
This PR introduces two main improvements to the apko build action:

1. Added docker-args input: Users can now pass additional arguments to the docker run command (e.g., custom mounts for certificates or environment variables) via the docker-args input.
2. Improved compatibility for generic-user: Wrapped the generic-user input in single quotes to prevent potential parsing errors or issues when usernames contain special characters (like #).