### PR TITLE
chore: consolidate dependabot config and group patch updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,27 +1,28 @@
 version: 2
 updates:
-  # workflows
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/vul-scans"
+      - "/tag"
+      - "/apko-snapshot"
+      - "/scan-apk"
     schedule:
       interval: "weekly"
-  # vul-scans
-  - package-ecosystem: "github-actions"
-    directory: "/vul-scans"
-    schedule:
-      interval: "weekly"
-  # tag
-  - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 3
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+
+  - package-ecosystem: "gomod"
     directory: "/tag"
     schedule:
       interval: "weekly"
-  # apko-snapshot
-  - package-ecosystem: "github-actions"
-    directory: "/apko-snapshot"
-    schedule:
-      interval: "weekly"
-  # scan-apk
-  - package-ecosystem: "github-actions"
-    directory: "/scan-apk"
-    schedule:
-      interval: "weekly"
+    cooldown:
+      default-days: 3
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary
- Merge the five separate `github-actions` Dependabot entries into a single entry using `directories` (`/`, `/vul-scans`, `/tag`, `/apko-snapshot`, `/scan-apk`)
- Add a `gomod` entry for `/tag` (previously untracked)
- Group patch releases via a `patch-updates` group
- Add a 3-day cooldown before opening update PRs

## Notes
- `apko-build`, `apko-publish`, and `release-monitoring` reference no external actions, so they need no coverage.
- With `directories`, patch grouping is per-directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)